### PR TITLE
Add 'language_code' parameter to the parser interface

### DIFF
--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -3,20 +3,27 @@ import pytest
 
 def request_tests():
     return {
-        "2ml": {
+        ("en", "2ml"): {
             "magnitude": 2,
             "units": "ml",
         },
-        "2 kCal": {
+        ("en", "2 kCal"): {
             "magnitude": 2,
             "units": "cal",  # TODO: is there a clearer way to represent calorie units? https://en.wikipedia.org/wiki/Calorie  # noqa
         },
     }.items()
 
 
-@pytest.mark.parametrize("description,expected", request_tests())
-def test_request(client, description, expected):
-    response = client.post("/", data={"descriptions[]": description})
+@pytest.mark.parametrize("context, expected", request_tests())
+def test_request(client, context, expected):
+    language_code, description = context
+    response = client.post(
+        "/",
+        data={
+            "language_code": "en",
+            "descriptions[]": description,
+        },
+    )
     result = response.json
 
     assert expected in result

--- a/web/app.py
+++ b/web/app.py
@@ -6,7 +6,7 @@ app = Flask(__name__)
 pint = UnitRegistry()
 
 
-def parse_quantity(description):
+def parse_quantity(language, description):
     total = 0
     quantities = Ingreedy().parse(description)["quantity"]
     for quantity in quantities:
@@ -36,12 +36,13 @@ def get_base_units(quantity):
 
 @app.route("/", methods=["POST"])
 def root():
+    language = request.form.get("language_code", type=str, default="en")
     descriptions = request.form.getlist("descriptions[]")
     descriptions = [d.strip() for d in descriptions]
 
     quantities = []
     for description in descriptions:
-        magnitude, units = parse_quantity(description)
+        magnitude, units = parse_quantity(language, description)
         quantities.append(
             {
                 "magnitude": magnitude,

--- a/web/app.py
+++ b/web/app.py
@@ -6,7 +6,7 @@ app = Flask(__name__)
 pint = UnitRegistry()
 
 
-def parse_quantity(language, description):
+def parse_quantity(language_code, description):
     total = 0
     quantities = Ingreedy().parse(description)["quantity"]
     for quantity in quantities:
@@ -36,13 +36,13 @@ def get_base_units(quantity):
 
 @app.route("/", methods=["POST"])
 def root():
-    language = request.form.get("language_code", type=str, default="en")
+    language_code = request.form.get("language_code", type=str, default="en")
     descriptions = request.form.getlist("descriptions[]")
     descriptions = [d.strip() for d in descriptions]
 
     quantities = []
     for description in descriptions:
-        magnitude, units = parse_quantity(language, description)
+        magnitude, units = parse_quantity(language_code, description)
         quantities.append(
             {
                 "magnitude": magnitude,


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
Due to intrinsic complexity in natural language descriptions of ingredients, sometimes unit names (for example, `ML`) can be ambiguous.

A prerequisite for handling that in the logic-based parsing in this service is to have some knowledge of the language of the input text.  So, let's add a `language_code` parameter to the parser interface that this service provides.

### Briefly summarize the changes
1. Add `language_code` -- a string type, with default `en` for now -- to the parameters retrieved from `POST /` form submissions.

### How have the changes been tested?
1. Local development testing.
1. Basic unit test coverage is provided.

**List any issues that this change relates to**
Supports #2.