### PR TITLE
Add support for language-specific quantity handling

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -84,6 +84,10 @@ jinja2==3.1.4 \
     # via
     #   -r requirements.txt
     #   flask
+language-tags==1.2.0 \
+    --hash=sha256:d815604622242fdfbbfd747b40c31213617fd03734a267f2e39ee4bd73c88722 \
+    --hash=sha256:e934acba3e3dc85f867703eca421847a9ab7b7679b11b5d5cfd096febbf8bde6
+    # via -r requirements.txt
 markupsafe==2.1.5 \
     --hash=sha256:00e046b6dd71aa03a41079792f8473dc494d564611a8f89bbbd7cb93295ebdcf \
     --hash=sha256:075202fa5b72c86ad32dc7d0b56024ebdbcf2048c0ba09f1cde31bfdd57bcfff \

--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,5 @@
 flask==3.0.3
 gunicorn==23.0.0
 ingreedypy==1.3.8
+language-tags==1.2.0
 pint==0.24.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,6 +37,10 @@ jinja2==3.1.4 \
     --hash=sha256:4a3aee7acbbe7303aede8e9648d13b8bf88a429282aa6122a993f0ac800cb369 \
     --hash=sha256:bc5dd2abb727a5319567b7a813e6a2e7318c39f4f487cfe6c89c6f9c7d25197d
     # via flask
+language-tags==1.2.0 \
+    --hash=sha256:d815604622242fdfbbfd747b40c31213617fd03734a267f2e39ee4bd73c88722 \
+    --hash=sha256:e934acba3e3dc85f867703eca421847a9ab7b7679b11b5d5cfd096febbf8bde6
+    # via -r requirements.in
 markupsafe==2.1.5 \
     --hash=sha256:00e046b6dd71aa03a41079792f8473dc494d564611a8f89bbbd7cb93295ebdcf \
     --hash=sha256:075202fa5b72c86ad32dc7d0b56024ebdbcf2048c0ba09f1cde31bfdd57bcfff \

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -11,6 +11,10 @@ def request_tests():
             "magnitude": 2,
             "units": "cal",  # TODO: is there a clearer way to represent calorie units? https://en.wikipedia.org/wiki/Calorie  # noqa
         },
+        ("sk", "3 PL"): {
+            "magnitude": 18,
+            "units": "ml",
+        },
     }.items()
 
 

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -12,7 +12,7 @@ def request_tests():
             "units": "cal",  # TODO: is there a clearer way to represent calorie units? https://en.wikipedia.org/wiki/Calorie  # noqa
         },
         ("sk", "3 PL"): {
-            "magnitude": 44.36,  # TODO: check for variance in tablespoon/teaspoon conversions
+            "magnitude": 44.36,  # TODO: check variance of spoon-related conversions
             "units": "ml",
         },
     }.items()

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -12,7 +12,7 @@ def request_tests():
             "units": "cal",  # TODO: is there a clearer way to represent calorie units? https://en.wikipedia.org/wiki/Calorie  # noqa
         },
         ("sk", "3 PL"): {
-            "magnitude": 18,
+            "magnitude": 44.36,  # TODO: check for variance in tablespoon/teaspoon conversions
             "units": "ml",
         },
     }.items()

--- a/web/app.py
+++ b/web/app.py
@@ -7,6 +7,17 @@ pint = UnitRegistry()
 
 
 def normalize_unit(language_code, unit):
+    if language_code[:2].lower() in {"cs", "sk"}:
+        spoon_units = {
+            "cl": ("ml", 6),  # čajová lžička
+            "CL": ("ml", 6),  # cL would be less-ambiguous
+            "ML": ("ml", 2),  # mL would be less-ambiguous
+            "pl": ("ml", 6),  # polévková lžíce
+            "PL": ("ml", 6),
+        }
+        if unit in spoon_units:
+            return spoon_units[unit]
+
     return unit, 1
 
 

--- a/web/app.py
+++ b/web/app.py
@@ -11,8 +11,8 @@ def normalize_unit(language_code, unit):
     if language.tag(language_code).language.format in {"cs", "sk"}:
         spoon_units = {
             "cl": ("teaspoons", 1),  # čajová lžička
-            "CL": ("teaspoons", 1),  # cL would be less-ambiguous
-            "ML": ("teaspoons", 1),  # mL would be less-ambiguous
+            "CL": ("teaspoons", 1),  # cL would imply centiliters
+            "ML": ("teaspoons", 1),  # mL would imply milliliters
             "pl": ("tablespoons", 1),  # polévková lžíce
             "PL": ("tablespoons", 1),
         }

--- a/web/app.py
+++ b/web/app.py
@@ -1,5 +1,6 @@
 from flask import Flask, jsonify, request
 from ingreedypy import Ingreedy
+from language_tags import tags as language
 from pint import UnitRegistry
 
 app = Flask(__name__)
@@ -7,7 +8,7 @@ pint = UnitRegistry()
 
 
 def normalize_unit(language_code, unit):
-    if language_code[:2].lower() in {"cs", "sk"}:
+    if language.tag(language_code).language.format in {"cs", "sk"}:
         spoon_units = {
             "cl": ("teaspoons", 1),  # čajová lžička
             "CL": ("teaspoons", 1),  # cL would be less-ambiguous

--- a/web/app.py
+++ b/web/app.py
@@ -9,11 +9,11 @@ pint = UnitRegistry()
 def normalize_unit(language_code, unit):
     if language_code[:2].lower() in {"cs", "sk"}:
         spoon_units = {
-            "cl": ("ml", 6),  # čajová lžička
-            "CL": ("ml", 6),  # cL would be less-ambiguous
-            "ML": ("ml", 2),  # mL would be less-ambiguous
-            "pl": ("ml", 6),  # polévková lžíce
-            "PL": ("ml", 6),
+            "cl": ("teaspoons", 1),  # čajová lžička
+            "CL": ("teaspoons", 1),  # cL would be less-ambiguous
+            "ML": ("teaspoons", 1),  # mL would be less-ambiguous
+            "pl": ("tablespoons", 1),  # polévková lžíce
+            "PL": ("tablespoons", 1),
         }
         if unit in spoon_units:
             return spoon_units[unit]

--- a/web/app.py
+++ b/web/app.py
@@ -6,11 +6,18 @@ app = Flask(__name__)
 pint = UnitRegistry()
 
 
+def normalize_unit(language_code, unit):
+    return unit, 1
+
+
 def parse_quantity(language_code, description):
     total = 0
     quantities = Ingreedy().parse(description)["quantity"]
     for quantity in quantities:
-        total += pint.Quantity(quantity["amount"], quantity["unit"])
+        unit, amount = quantity["unit"], quantity["amount"]
+        normalized_unit, conversion_factor = normalize_unit(language_code, unit)
+        normalized_amount = amount * conversion_factor
+        total += pint.Quantity(normalized_amount, normalized_unit)
 
     base_units = get_base_units(total) or total.units
     total = total.to(base_units)


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
There's likely to be some regional/linguistic ambiguity when parsing ingredient descriptions, because they are written in natural language, and terms and abbreviations may overlap, either between similar cultures or distinct cultures.

This changeset adds support for custom logic to attempt to resolve that ambiguity using rule-based logic.  That won't be perfect in every case, and perhaps never will be, but it is explainable.

A motivating use-case, parsing of spoon-related abbreviations found in Czech and Slovak recipes, is implemented.

### Briefly summarize the changes
1. Use the `language_code` to override some of the default quantity handling logic.

### How have the changes been tested?
1. Unit test coverage is provided.

**List any issues that this change relates to**
Resolves #2.